### PR TITLE
805: Changing request path prefix from /api/rcs to /rcs/api

### DIFF
--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/ConsentDecisionApi.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/ConsentDecisionApi.java
@@ -37,7 +37,7 @@ public interface ConsentDecisionApi {
             @ApiResponse(code = 200, message = "A redirection response, specifying the URI the PSU should be redirected to",
                     response = RedirectionAction.class)
     })
-    @RequestMapping(value = "/api/rcs/consent/decision",
+    @RequestMapping(value = "/rcs/api/consent/decision",
             consumes = {"application/json; charset=utf-8"},
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/ConsentDetailsApi.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/ConsentDetailsApi.java
@@ -31,7 +31,7 @@ public interface ConsentDetailsApi {
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Consent details", response = ConsentDetails.class)
     })
-    @RequestMapping(value = "/api/rcs/consent/details",
+    @RequestMapping(value = "/rcs/api/consent/details",
             consumes = {"application/jwt; charset=utf-8", "application/json; charset=utf-8"},
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/details/ConsentDetails.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/details/ConsentDetails.java
@@ -61,6 +61,6 @@ public abstract class ConsentDetails {
     public abstract IntentType getIntentType();
 
     public String getDecisionApiUri() {
-        return "/api/rcs/consent/decision/";
+        return "/rcs/api/consent/decision/";
     }
 }

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/api/ConsentDecisionApiControllerTest.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/api/ConsentDecisionApiControllerTest.java
@@ -90,7 +90,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 public class ConsentDecisionApiControllerTest {
 
     private static final String BASE_URL = "http://localhost:";
-    private static final String CONTEXT_DETAILS_URI = "/api/rcs/consent/decision";
+    private static final String CONTEXT_DETAILS_URI = "/rcs/api/consent/decision";
     @LocalServerPort
     private int port;
     @MockBean

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/api/ConsentDetailsApiControllerTest.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/api/ConsentDetailsApiControllerTest.java
@@ -90,7 +90,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 @SpringBootTest(classes = RcsApplicationTestSupport.class, webEnvironment = RANDOM_PORT)
 public class ConsentDetailsApiControllerTest {
     private static final String BASE_URL = "http://localhost:";
-    private static final String CONTEXT_DETAILS_URI = "/api/rcs/consent/details";
+    private static final String CONTEXT_DETAILS_URI = "/rcs/api/consent/details";
     private final Gson gson = new GsonBuilder().registerTypeAdapter(DateTime.class, new JsonDeserializer<DateTime>() {
         @Override
         public DateTime deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)


### PR DESCRIPTION
Using request path prefix /rcs/api to make this consistent with other ingress paths.

This will produce cleaner ingress and IG configuration when we run this component behind IG.
- /rcs/api will go to the backend
- /rcs/ui will go to the frontend

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/805