### PR TITLE
816: Configuring RCS to use RS internal service address for backoffice API queries

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rcs/templates/deployment.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rcs/templates/deployment.yaml
@@ -66,11 +66,11 @@ spec:
                configMapKeyRef:
                  name: securebanking-platform-config
                  key: IDENTITY_PLATFORM_FQDN
-          - name: RS_FQDN
+          - name: RS_INTERNAL_SVC
             valueFrom:
               configMapKeyRef:
                 name: securebanking-platform-config
-                key: RS_FQDN
+                key: RS_INTERNAL_SVC
           - name: SERVER_PORT
             value: {{ .Values.deployment.server.port | quote }}
           - name: SPRING_CLOUD_CONFIG_URI

--- a/securebanking-openbanking-uk-rcs-sample/docker/config/securebanking-openbanking-uk-rcs-docker.yml
+++ b/securebanking-openbanking-uk-rcs-sample/docker/config/securebanking-openbanking-uk-rcs-docker.yml
@@ -61,10 +61,10 @@ rcs:
     request:
       jwt:
         must-be-validated: false
-  rs_fqdn: ${RS_FQDN:http://rs-simulator:8080}
 
 # used in RCS to call rs backoffice endpoints
 rs:
+  baseUri: http://${rs.internal.svc}:8080
   backoffice:
     uris:
       accounts:

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/client/rs/AccountService.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/client/rs/AccountService.java
@@ -18,7 +18,7 @@ package com.forgerock.securebanking.openbanking.uk.rcs.client.rs;
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRAccount;
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRAccountWithBalance;
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.common.FRAccountIdentifier;
-import com.forgerock.securebanking.openbanking.uk.rcs.configuration.RcsConfigurationProperties;
+import com.forgerock.securebanking.openbanking.uk.rcs.configuration.RsConfiguration;
 import com.forgerock.securebanking.openbanking.uk.rcs.configuration.RsBackofficeConfiguration;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.ParameterizedTypeReference;
@@ -38,16 +38,16 @@ import static org.springframework.web.util.UriComponentsBuilder.fromHttpUrl;
 public class AccountService {
 
     private final RestTemplate restTemplate;
-    private final RcsConfigurationProperties configurationProperties;
+    private final RsConfiguration rsConfiguration;
     private final RsBackofficeConfiguration rsBackofficeConfiguration;
 
     public AccountService(
             RestTemplate restTemplate,
-            RcsConfigurationProperties configurationProperties,
+            RsConfiguration rsConfiguration,
             RsBackofficeConfiguration rsBackofficeConfiguration
     ) {
         this.restTemplate = restTemplate;
-        this.configurationProperties = configurationProperties;
+        this.rsConfiguration = rsConfiguration;
         this.rsBackofficeConfiguration = rsBackofficeConfiguration;
     }
 
@@ -59,7 +59,7 @@ public class AccountService {
         ParameterizedTypeReference<List<FRAccount>> ptr = new ParameterizedTypeReference<>() {
         };
         UriComponentsBuilder builder = fromHttpUrl(
-                configurationProperties.getRsFqdnURIAsString() +
+                rsConfiguration.getBaseUri() +
                         rsBackofficeConfiguration.getAccounts().get(
                                 RsBackofficeConfiguration.UriContexts.FIND_USER_BY_ID.toString()
                         )
@@ -79,7 +79,7 @@ public class AccountService {
         ParameterizedTypeReference<List<FRAccountWithBalance>> ptr = new ParameterizedTypeReference<>() {
         };
         UriComponentsBuilder builder = fromHttpUrl(
-                configurationProperties.getRsFqdnURIAsString() +
+                rsConfiguration.getBaseUri() +
                         rsBackofficeConfiguration.getAccounts().get(
                                 RsBackofficeConfiguration.UriContexts.FIND_USER_BY_ID.toString()
                         )
@@ -100,7 +100,7 @@ public class AccountService {
         };
 
         UriComponentsBuilder builder = fromHttpUrl(
-                configurationProperties.getRsFqdnURIAsString() +
+                rsConfiguration.getBaseUri() +
                         rsBackofficeConfiguration.getAccounts().get(
                                 RsBackofficeConfiguration.UriContexts.FIND_BY_ACCOUNT_IDENTIFIERS.toString()
                         )
@@ -124,7 +124,7 @@ public class AccountService {
         };
 
         UriComponentsBuilder builder = fromHttpUrl(
-                configurationProperties.getRsFqdnURIAsString() +
+                rsConfiguration.getBaseUri() +
                         rsBackofficeConfiguration.getAccounts().get(
                                 RsBackofficeConfiguration.UriContexts.FIND_BY_ACCOUNT_IDENTIFIERS.toString()
                         )

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/client/rs/DomesticPaymentService.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/client/rs/DomesticPaymentService.java
@@ -16,7 +16,7 @@
 package com.forgerock.securebanking.openbanking.uk.rcs.client.rs;
 
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRWriteDomestic;
-import com.forgerock.securebanking.openbanking.uk.rcs.configuration.RcsConfigurationProperties;
+import com.forgerock.securebanking.openbanking.uk.rcs.configuration.RsConfiguration;
 import com.forgerock.securebanking.openbanking.uk.rcs.configuration.RsBackofficeConfiguration;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.ParameterizedTypeReference;
@@ -36,17 +36,17 @@ import static org.springframework.web.util.UriComponentsBuilder.fromHttpUrl;
 public class DomesticPaymentService {
 
     private final RestTemplate restTemplate;
-    private final RcsConfigurationProperties configurationProperties;
+    private final RsConfiguration rsConfiguration;
     private final RsBackofficeConfiguration rsBackofficeConfiguration;
 
     public DomesticPaymentService(
             RestTemplate restTemplate,
-            RcsConfigurationProperties configurationProperties,
+            RsConfiguration rsConfiguration,
             RsBackofficeConfiguration rsBackofficeConfiguration
 
     ) {
         this.restTemplate = restTemplate;
-        this.configurationProperties = configurationProperties;
+        this.rsConfiguration = rsConfiguration;
         this.rsBackofficeConfiguration = rsBackofficeConfiguration;
     }
 
@@ -58,7 +58,7 @@ public class DomesticPaymentService {
         ParameterizedTypeReference<List<FRWriteDomestic>> ptr = new ParameterizedTypeReference<>() {
         };
         UriComponentsBuilder builder = fromHttpUrl(
-                configurationProperties.getRsFqdnURIAsString() +
+                rsConfiguration.getBaseUri() +
                         rsBackofficeConfiguration.getDomesticPayments().get(
                                 RsBackofficeConfiguration.UriContexts.FIND_USER_BY_ID.toString()
                         )

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/configuration/RsConfiguration.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/configuration/RsConfiguration.java
@@ -17,29 +17,14 @@ package com.forgerock.securebanking.openbanking.uk.rcs.configuration;
 
 import lombok.Data;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.util.LinkedCaseInsensitiveMap;
-
-import java.net.URI;
-import java.util.Map;
 
 import java.net.URI;
 
 @Configuration
 @Data
-public class RcsConfigurationProperties {
-    private static final String _delimiter = "://";
-    @Value("${rcs.rs_fqdn}")
-    private String rsFqdn;
-    @Value("${rcs.schema:https}")
-    private String schema;
+public class RsConfiguration {
 
-    public String getRsFqdnURIAsString() {
-        return String.join(_delimiter, schema, rsFqdn);
-    }
-
-    public URI getRsFqdnURI() {
-        return URI.create(String.join(_delimiter, schema, rsFqdn));
-    }
+    @Value("${rs.baseUri}")
+    private String baseUri;
 }

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/configuration/RcsConfigurationPropertiesTest.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/configuration/RcsConfigurationPropertiesTest.java
@@ -27,23 +27,22 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Unit test for {@link RcsConfigurationProperties}
+ * Unit test for {@link RsConfiguration}
  */
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = {RcsConfigurationProperties.class, RsBackofficeConfiguration.class}, initializers = ConfigFileApplicationContextInitializer.class)
+@ContextConfiguration(classes = {RsConfiguration.class, RsBackofficeConfiguration.class}, initializers = ConfigFileApplicationContextInitializer.class)
 @EnableConfigurationProperties(value = RsBackofficeConfiguration.class)
 @ActiveProfiles("test")
 public class RcsConfigurationPropertiesTest {
 
     @Autowired
-    private RcsConfigurationProperties configurationProperties;
+    private RsConfiguration configurationProperties;
     @Autowired
     private RsBackofficeConfiguration rsBackofficeConfiguration;
 
     @Test
     public void shouldHaveAllRCSProperties() {
-        assertThat(configurationProperties.getRsFqdn()).isNotNull();
-        assertThat(configurationProperties.getSchema()).isNotNull();
+        assertThat(configurationProperties.getBaseUri()).isNotNull();
     }
 
     @Test

--- a/securebanking-openbanking-uk-rcs-server/src/test/resources/application-test.yml
+++ b/securebanking-openbanking-uk-rcs-server/src/test/resources/application-test.yml
@@ -50,10 +50,8 @@ rcs:
         issuer: secure-open-banking-rcs
         signingAlgorithm: PS256
 
-  rs_fqdn: ${RS_FQDN:localhost}
-  schema: https
-
 rs:
+  baseUri: http://${rs.internal.svc:localhost}:8080
   backoffice:
     uris:
       accounts:


### PR DESCRIPTION
Configuring RS address via new spring config: `rs.baseUri: http://${rs.internal.svc}:8080`

This uses the RS_INTERNAL_SVC environment variable (as provided by the config map).

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/816